### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/org-capture-pop-frame.el
+++ b/org-capture-pop-frame.el
@@ -6,6 +6,7 @@
 ;; Author: Feng Shu <tumashu@163.com>
 ;; URL: https://github.com/tumashu/org-capture-pop-frame.git
 ;; Version: 0.0.1
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Because advice-add was introduced at Emacs 24.4.
