### PR TITLE
Close the popup frame after pressing "q" or "C-g"

### DIFF
--- a/org-capture-pop-frame.el
+++ b/org-capture-pop-frame.el
@@ -141,7 +141,13 @@ set by `ocpf---org-capture'."
                (select-frame frame)
                (setq word-wrap nil)
                (setq truncate-lines nil)
-               (funcall orig-fun goto keys)
+
+               ;; Close the popup frame after pressing "q" or "C-g".
+               ;; https://github.com/malb/emacs.d/blame/197be098ad50d8d7aca4513d63db8705b30017e4/malb.org#L3196-L3198.
+               (condition-case nil
+                   (funcall orig-fun goto keys)
+                 ((debug error) (ocpf--delete-frame)))
+
                (setq header-line-format
                      (list "Capture buffer. "
                            (propertize (substitute-command-keys "Finish \\[org-capture-finalize], ")


### PR DESCRIPTION
At any point during the capture process, e.g., at the first "Select a capture template", during input.

With "q", a user-error is signaled.
https://github.com/emacsmirror/org/blob/ef4d8adcaa57da0b0ddcea7fbf4fa2150cac3f96/lisp/org-capture.el#L692-L693.

With "C-g", an error is raised.
- https://github.com/emacsmirror/org/blob/ef4d8adcaa57da0b0ddcea7fbf4fa2150cac3f96/lisp/org-capture.el#L714-L716
- https://github.com/emacsmirror/org/blob/ef4d8adcaa57da0b0ddcea7fbf4fa2150cac3f96/lisp/org-capture.el#L722-L729